### PR TITLE
Update to RISC Zero zkVM 1.2.2, enable support for segment limit po2

### DIFF
--- a/checkers/common/checker-api.bash
+++ b/checkers/common/checker-api.bash
@@ -159,5 +159,7 @@ run_risc0() {
     #   XXX dup from test_rust; we should abstract this somehow
     local ncg="${nocertgen:+RISC0_DEV_MODE=1}"
 
+    # TODO: pass --segment-limit-po2 21 if running on 4090
+
     $dry env $ncg "$BUILD/$ver/$command" "$@" || fail
 }

--- a/checkers/mm/mm-risc0/host/Cargo.toml
+++ b/checkers/mm/mm-risc0/host/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 methods = { path = "../methods" }
-risc0-zkvm = { version = "=1.0.5", default-features = false, features = ["prove"]}
+risc0-zkvm = { version = "=1.2.2", default-features = false, features = ["prove"]}
 bincode = "1.3"
 mmtokens = { path = "../../common/mmtokens" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/checkers/mm/mm-risc0/methods/Cargo.toml
+++ b/checkers/mm/mm-risc0/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = { version = "=1.0.5" }
+risc0-build = { version = "=1.2.2" }
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/checkers/mm/mm-risc0/methods/guest/Cargo.toml
+++ b/checkers/mm/mm-risc0/methods/guest/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "=1.0.5", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "=1.2.2", default-features = false, features = ['std'] }
 mmtokens = { path = "../../../common/mmtokens" }
 mmlib = { path = "../../../common/mmlib", default-features = false, features = ['use_hints'] }


### PR DESCRIPTION
Note: a `TODO` has been left in `checker-api.bash` for the upstream maintainers (checker should specify `--segment-limit-po2 21` when running on nVidia 4090)